### PR TITLE
Update angular/cli dependency

### DIFF
--- a/app-a/package.json
+++ b/app-a/package.json
@@ -26,7 +26,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.4",
+    "@angular/cli": "1.6.5",
     "@angular/compiler-cli": "^5.0.0",
     "@angular/language-service": "^5.0.0",
     "@types/jasmine": "~2.5.53",

--- a/app-b/package.json
+++ b/app-b/package.json
@@ -26,7 +26,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.4",
+    "@angular/cli": "1.6.5",
     "@angular/compiler-cli": "^5.0.0",
     "@angular/language-service": "^5.0.0",
     "@types/jasmine": "~2.5.53",


### PR DESCRIPTION
When cloning this repo and trying to run `npm run build`, I get the following error: 

```
Error: Cannot find module '@angular-devkit/core'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/frederik/Development/samples/microservice-angular-iframe/app-b/node_modules/@angular-devkit/schematics/src/tree/virtual.js:10:16)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
```

Updating the version of `@angular/cli` to `1.6.5`, as mentioned in https://github.com/angular/angular-cli/issues/9307, resolves it.